### PR TITLE
fix music extraction bug

### DIFF
--- a/src/resources/readgamedata/preparedata.cpp
+++ b/src/resources/readgamedata/preparedata.cpp
@@ -2670,16 +2670,14 @@ void PrepareData::ExtractMusic() {
     //this position
     fseek(iFile, size - 4, SEEK_SET);
 
-    unsigned long seekPos;
+    // unsigned long is larger than the 4 bytes read. initializing it to 0 avoids
+    // the upper bytes containing garbage.
+    unsigned long seekPos = 0;
 
-    fread(&seekPos, sizeof(seekPos), 1, iFile);
-    if (seekPos > size) {
-        fclose(iFile);
-        throw std::string("Error - Invalid seek position in music file (hint: little/big endian mistake?)");
-    }
+    fread(&seekPos, 4, 1, iFile);
     fseek(iFile, seekPos, SEEK_SET);
 
-    short int readVal;
+    short int readVal = 0;
     unsigned int N = 0;
     size_t lastSeekPos;
 
@@ -2687,7 +2685,7 @@ void PrepareData::ExtractMusic() {
     //lets call the amount of repetitions N
     do {
         lastSeekPos = ftell(iFile);
-        fread(&readVal, sizeof(readVal), 1, iFile);
+        fread(&readVal, 2, 1, iFile);
         if (readVal == 0x01)
             N++;
     } while (readVal == 0x01);
@@ -2699,6 +2697,9 @@ void PrepareData::ExtractMusic() {
     fseek(iFile, lastSeekPos, SEEK_SET);
 
     std::vector<MUSICTABLEENTRY> VecMusicTableEntries;
+
+    // Integer sizes are not well defined, so better check them
+    static_assert(sizeof(MUSICTABLEENTRY) == 16);
 
     MUSICTABLEENTRY *newTableEntry;
 
@@ -2716,6 +2717,9 @@ void PrepareData::ExtractMusic() {
     std::vector<MUSICTABLEENTRY>::iterator it;
 
     std::vector<SOUNDFILEENTRY> VecTuneInformation;
+
+    // Integer sizes are not well defined, so better check them
+    static_assert(sizeof(SOUNDFILEENTRY) == 32);
 
     SOUNDFILEENTRY *newTuneInformation;
     unsigned long targetLenTuneSum;


### PR DESCRIPTION
The problem was not a byte-order bug, as I thought originally. What really happened was that we were reading 4 bytes into a 8 byte `unsigned long`. This failed for me because the remaining 4 bytes contained garbage.

I have a few hypotheses why it has worked in the past:
1. Maybe you ran this code the last time long ago on a 32 bit machine where `unsigned long` really has 4 bytes?
2. I ran the code in Debug mode, which initializes all variables with a deterministic non-zero bit pattern. In release mode you may have been lucky that the garbage bytes were actually zero.

Anyway, my fix of setting the variable to 0 seems to work. A better approach might be to use a deterministic size integer, but I don't know where to include them from...