### PR TITLE
Fix crash in debug mode

### DIFF
--- a/src/input/input.cpp
+++ b/src/input/input.cpp
@@ -62,4 +62,6 @@ bool MyEventReceiver::IsKeyDownSingleEvent(EKEY_CODE keyCode) {
         KeyIsLockedCurr[keyCode] = true;
         return true;
     }
+
+    return false;
 }


### PR DESCRIPTION
Actually, what caused the crash for me when entering the menu in Debug mode was a missing return statement at the end of a function. I hate C(++) :)